### PR TITLE
Fix process.env not defined error

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,15 +1,15 @@
 import OpenAI from 'openai';
 
-// Obtener la API key de las variables de entorno
-const apiKey = process.env.OPENAI_API_KEY;
+// Obtener la API key de las variables de entorno de Vite
+const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
 
 if (!apiKey) {
-  throw new Error('OPENAI_API_KEY no está definida en las variables de entorno');
+  throw new Error('VITE_OPENAI_API_KEY no está definida en las variables de entorno');
 }
 
 export const openai = new OpenAI({
   apiKey: apiKey,
-  organization: process.env.OPENAI_ORG_ID // Opcional
+  organization: import.meta.env.VITE_OPENAI_ORG_ID // Opcional
 });
 
 // Función auxiliar para manejar errores de la API

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_OPENAI_API_KEY: string
+  readonly VITE_OPENAI_ORG_ID?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
- Replace process.env with import.meta.env for Vite compatibility
- Add proper TypeScript types for environment variables
- Update vite-env.d.ts with ImportMetaEnv interface