### PR TITLE
Add dedicated Integrations page in Settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AccountsSettings } from './components/settings/AccountsSettings';
 import { ProfileSettings } from './components/settings/ProfileSettings';
 import { CalendarSettings } from './components/settings/CalendarSettings';
 import { NotificationsSettings } from './components/settings/NotificationsSettings';
+import { IntegrationsSettings } from './components/settings/IntegrationsSettings';
 import { Login } from './components/Login';
 import { PublicPage } from './components/public/PublicPage';
 import { Campaigns } from './components/campaigns/Campaigns';
@@ -71,6 +72,7 @@ function App() {
                         <Route path="accounts" element={<AccountsSettings />} />
                         <Route path="calendar" element={<CalendarSettings />} />
                         <Route path="notifications" element={<NotificationsSettings />} />
+                        <Route path="integrations" element={<IntegrationsSettings />} />
                       </Route>
                     </Routes>
                   </main>

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { OpenAIConfig } from './OpenAIConfig';
+
+export function IntegrationsSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Integraciones</h2>
+        <p className="text-gray-600 mb-6">
+          Configura las integraciones con servicios externos para mejorar la funcionalidad de la plataforma.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <img 
+                  src="https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg" 
+                  alt="OpenAI Logo" 
+                  className="h-8 w-8"
+                />
+                <div>
+                  <h3 className="text-lg font-medium text-gray-900">OpenAI</h3>
+                  <p className="text-sm text-gray-500">Configura tu API key de OpenAI para habilitar las funciones de IA</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="px-6 py-4">
+            <OpenAIConfig />
+          </div>
+        </div>
+
+        {/* Add more integration sections here */}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsLayout.tsx
+++ b/src/components/settings/SettingsLayout.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
-import { User, Calendar, Bell, Link as LinkIcon } from 'lucide-react';
+import { User, Calendar, Bell, Link as LinkIcon, Plug } from 'lucide-react';
 
 const settingsMenu = [
   { path: '/settings/profile', label: 'Perfil', icon: User },
   { path: '/settings/accounts', label: 'Cuentas conectadas', icon: LinkIcon },
   { path: '/settings/calendar', label: 'Calendario', icon: Calendar },
   { path: '/settings/notifications', label: 'Notificaciones', icon: Bell },
+  { path: '/settings/integrations', label: 'Integraciones', icon: Plug },
 ];
 
 export function SettingsLayout() {


### PR DESCRIPTION
## Changes

- Create IntegrationsSettings component with OpenAI configuration
- Add route for /settings/integrations
- Update settings menu with Integrations section
- Use Plug icon for better visual distinction

## How to access

1. Go to Settings
2. Click on Integraciones in the left menu
3. Configure your OpenAI API key in the form

## Features

- Clean and intuitive UI for managing integrations
- OpenAI integration as the first integration option
- Secure configuration storage in Firebase
- Easy access to all integration settings in one place