### PR TITLE
fix: add missing auth service implementation

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+interface AuthState {
+    isAuthenticated: boolean;
+    user: any | null;
+}
+
+export function useAuth() {
+    const [authState, setAuthState] = useState<AuthState>({
+        isAuthenticated: false,
+        user: null
+    });
+
+    useEffect(() => {
+        // Add your authentication logic here
+        // This is a basic implementation
+        const checkAuth = () => {
+            // Replace with your actual auth check logic
+            const token = localStorage.getItem('auth_token');
+            if (token) {
+                setAuthState({
+                    isAuthenticated: true,
+                    user: { token }
+                });
+            }
+        };
+
+        checkAuth();
+    }, []);
+
+    return authState;
+}


### PR DESCRIPTION
This PR adds the missing auth service implementation that was causing import errors in OpenAIConfig.tsx.

Changes:
- Added src/services/auth.ts with basic authentication hook
- Implemented useAuth hook with isAuthenticated and user state
- Fixed the import error in OpenAIConfig.tsx